### PR TITLE
fix: Default out the effect to an object to avoid crashing

### DIFF
--- a/src/sagaMonitor.ts
+++ b/src/sagaMonitor.ts
@@ -1,5 +1,6 @@
 import { SagaMonitor, Saga } from "@redux-saga/core"
 import * as is from "@redux-saga/is"
+import { Effect } from "@redux-saga/types"
 import { Reactotron } from "reactotron-core-client"
 
 import * as effectTypes from "./constants"
@@ -43,7 +44,7 @@ export default (reactotron: Reactotron, pluginConfig: PluginConfig = {}): SagaMo
           // Do Nothing for now
           break
         default:
-          extra = effect.effect.payload
+          extra = (effect.effect || {} as Effect).payload
           break
       }
     }


### PR DESCRIPTION
Adding fallback object to default case for buildChildEffects to stop unhandled Promise Rejection when effect has no name and is defaulted to UNKOWN.